### PR TITLE
GridColumn default style now overwritable.

### DIFF
--- a/src/grid/gridBody.js
+++ b/src/grid/gridBody.js
@@ -15,6 +15,8 @@ const mapColumns = (item, columns) =>
             style={column.style}
             className={column.className}
             flexGrow={column.flexGrow}
+            flexShrink={column.flexShrink}
+            flexBasis={column.flexBasis}
           >
             {fieldComponent}
           </GridColumn>);

--- a/src/grid/gridBody.js
+++ b/src/grid/gridBody.js
@@ -14,7 +14,6 @@ const mapColumns = (item, columns) =>
             key={i}
             style={column.style}
             className={column.className}
-            flexGrow={column.flexGrow}
           >
             {fieldComponent}
           </GridColumn>);

--- a/src/grid/gridBody.js
+++ b/src/grid/gridBody.js
@@ -14,6 +14,7 @@ const mapColumns = (item, columns) =>
             key={i}
             style={column.style}
             className={column.className}
+            flexGrow={column.flexGrow}
           >
             {fieldComponent}
           </GridColumn>);

--- a/src/grid/gridColumn.js
+++ b/src/grid/gridColumn.js
@@ -6,9 +6,10 @@ class GridColumnComponent extends React.Component {
         return !isEqual(this.props.children, nextProps.children);
     }
     render() {
-        const style = { flex: '1 0 0px' };
+        const flexSize = this.props.flexGrow || '1';
+        const style = { flex: `${flexSize} 0 0px` };
         return (
-          <div style={{ ...style, ...this.props.style, }} className={this.props.className}>
+          <div style={{ ...style, ...this.props.style }} className={this.props.className}>
             {this.props.children}
           </div>
         );
@@ -18,7 +19,8 @@ class GridColumnComponent extends React.Component {
 GridColumnComponent.propTypes = {
     children: PropTypes.element.isRequired,
     style: PropTypes.object,
-    className: PropTypes.string
+    className: PropTypes.string,
+    flexGrow: PropTypes.number
 };
 
 export default GridColumnComponent;

--- a/src/grid/gridColumn.js
+++ b/src/grid/gridColumn.js
@@ -6,10 +6,9 @@ class GridColumnComponent extends React.Component {
         return !isEqual(this.props.children, nextProps.children);
     }
     render() {
-        const flexSize = this.props.flexGrow || '1';
-        const style = { flex: `${flexSize} 0 0px` };
+        const style = { flex: '1 0 0px' };
         return (
-          <div style={{ ...this.props.style, ...style }} className={this.props.className}>
+          <div style={{ ...style, ...this.props.style, }} className={this.props.className}>
             {this.props.children}
           </div>
         );
@@ -19,8 +18,7 @@ class GridColumnComponent extends React.Component {
 GridColumnComponent.propTypes = {
     children: PropTypes.element.isRequired,
     style: PropTypes.object,
-    className: PropTypes.string,
-    flexGrow: PropTypes.number
+    className: PropTypes.string
 };
 
 export default GridColumnComponent;

--- a/src/grid/gridColumn.js
+++ b/src/grid/gridColumn.js
@@ -7,9 +7,11 @@ class GridColumnComponent extends React.Component {
     }
     render() {
         const flexSize = this.props.flexGrow || '1';
-        const style = { flex: `${flexSize} 0 0px` };
+        const flexShrink = this.props.flexShrink || '0';
+        const flexBasis = this.props.flexBasis || '0px';
+        const style = { flex: `${flexSize} ${flexShrink} ${flexBasis}` };
         return (
-          <div style={{ ...style, ...this.props.style }} className={this.props.className}>
+          <div style={{ ...this.props.style, ...style }} className={this.props.className}>
             {this.props.children}
           </div>
         );
@@ -20,7 +22,9 @@ GridColumnComponent.propTypes = {
     children: PropTypes.element.isRequired,
     style: PropTypes.object,
     className: PropTypes.string,
-    flexGrow: PropTypes.number
+    flexGrow: PropTypes.number,
+    flexShrink: PropTypes.number,
+    flexBasis: PropTypes.number
 };
 
 export default GridColumnComponent;

--- a/src/grid/gridHeader.js
+++ b/src/grid/gridHeader.js
@@ -4,7 +4,9 @@ import map from 'lodash/map';
 const renderColumnHeaders = columns => (
     map(columns, (column, i) => {
         const flexSize = column.flexGrow || '1';
-        const style = { flex: `${flexSize} 0 0px` };
+        const flexShrink = column.flexShrink || '0';
+        const flexBasis = column.flexBasis || '0px';
+        const style = { flex: `${flexSize} ${flexShrink} ${flexBasis}` };
         return (
           <div key={i} style={{ ...column.style, ...style }}>
             {column.header}


### PR DESCRIPTION
The default style of the GridColumn is 'flex: 1 0 0px'. This can now be overwritten by specifying a 'style' property with the 'flex' properties of your choice in the 'columns' array passed to the ReactFlexboxComponentGrid component.