### PR TITLE
Eliminate extra wrapper div around grid rows

### DIFF
--- a/src/grid/gridBody.js
+++ b/src/grid/gridBody.js
@@ -40,7 +40,7 @@ const createRow = (item, tableColumns, rowClickHandler, rowHeader, rowFooter, us
     }
 
     return (
-      <div key={item.id}>
+      <React.Fragment key={item.id}>
         {rowHeaderComponent}
         <GridRow
           rowClickHandler={rowClickHandler}
@@ -52,7 +52,7 @@ const createRow = (item, tableColumns, rowClickHandler, rowHeader, rowFooter, us
           {tableColumns}
         </GridRow>
         {rowFooterComponent}
-      </div>
+      </React.Fragment>
     );
 };
 


### PR DESCRIPTION
Replace wrapper `<div>` with a `<React Fragment>`.

**What Changed:**
Until now, the React component grid has wrapped each grid row in an empty wrapper div:
```
<div>
    <div>your actual grid content</div>
</div>
```
This makes the grid more difficult to style, especially for things like zebra striping, which require the contents to be siblings of each other. By replacing the wrapper div with a React Fragment, we not only clean up our markup, but potentially improve performance and make the grid easier to style.