### PR TITLE
remove meaningingless logic

### DIFF
--- a/lib/grid/gridBody.js
+++ b/lib/grid/gridBody.js
@@ -96,19 +96,9 @@ var createRow = function createRow(item, tableColumns, rowClickHandler, rowHeade
     );
 };
 
-var renderGridMap = function renderGridMap(oldRows, oldData, newData, columns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle, rowWrapperComponent) {
+var renderGridMap = function renderGridMap(newData, columns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle, rowWrapperComponent) {
     return newData.map(function (item) {
-        var oldDataPoint = (0, _find2.default)(oldData, function (eachOldData) {
-            return eachOldData.id === item.id;
-        });
-        var foundOldRow = (0, _find2.default)(oldRows, function (eachOldRow) {
-            return eachOldRow.key === item.id;
-        });
-        var oldRow = foundOldRow ? (0, _find2.default)(foundOldRow.children, function (child) {
-            return child.key === item.id;
-        }) : null;
-        var letsReRenderThisRow = !(oldDataPoint && (0, _isEqual2.default)(item, oldDataPoint));
-        var tableColumns = !letsReRenderThisRow && oldRow ? oldRow.props.children : mapColumns(item, columns, useDefaultStyle);
+        var tableColumns = mapColumns(item, columns, useDefaultStyle);
         return createRow(item, tableColumns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle, rowWrapperComponent);
     }, undefined);
 };
@@ -134,7 +124,7 @@ var GridBodyComponent = function (_React$Component) {
                 useDefaultStyle = _props.useDefaultStyle,
                 rowWrapperComponent = _props.rowWrapperComponent;
 
-            var tableRows = renderGridMap(null, null, data, columns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle, rowWrapperComponent);
+            var tableRows = renderGridMap(data, columns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle, rowWrapperComponent);
             this.setState({
                 tableRows: tableRows
             });

--- a/src/grid/gridBody.js
+++ b/src/grid/gridBody.js
@@ -59,16 +59,10 @@ const createRow = (item, tableColumns, rowClickHandler, rowHeader, rowFooter, us
     );
 };
 
-const renderGridMap = (oldRows, oldData, newData, columns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle,
+const renderGridMap = (newData, columns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle,
                        rowWrapperComponent) =>
     newData.map((item) => {
-        const oldDataPoint = find(oldData, eachOldData => eachOldData.id === item.id);
-        const foundOldRow = find(oldRows, eachOldRow => eachOldRow.key === item.id);
-        const oldRow = foundOldRow ? find(foundOldRow.children, child => child.key === item.id) : null;
-        const letsReRenderThisRow = (!(oldDataPoint && isEqual(item, oldDataPoint)));
-        const tableColumns = (!letsReRenderThisRow && oldRow) ?
-            oldRow.props.children :
-            mapColumns(item, columns, useDefaultStyle);
+        const tableColumns = mapColumns(item, columns, useDefaultStyle);
         return createRow(item, tableColumns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle,
             rowWrapperComponent);
     }, this);
@@ -79,8 +73,6 @@ class GridBodyComponent extends React.Component {
             data, columns, rowClickHandler, rowHeader, rowFooter, useDefaultStyle, rowWrapperComponent
         } = this.props;
         const tableRows = renderGridMap(
-            null,
-            null,
             data,
             columns,
             rowClickHandler,


### PR DESCRIPTION
your renderGripMap function is passing in two static parameters that are meaningless. They are two null parameters that do nothing. They are used in some meaningless complicated logic. I removed it to make your component more efficient. I ran npm test and it passed
@whitneyw 